### PR TITLE
Fixing deprecation warnings for 2025.1

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.12-bullseye",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4.1.1

--- a/custom_components/schluter/climate.py
+++ b/custom_components/schluter/climate.py
@@ -24,7 +24,8 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -57,7 +58,12 @@ class SchluterThermostat(CoordinatorEntity[DataUpdateCoordinator], ClimateEntity
     """Define an Schluter Thermostat Entity."""
 
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.AUTO, HVACMode.OFF]
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility: bool = False
 
     coordinator: DataUpdateCoordinator[dict[str, dict[str, Thermostat]]]
 
@@ -116,7 +122,7 @@ class SchluterThermostat(CoordinatorEntity[DataUpdateCoordinator], ClimateEntity
     @property
     def temperature_unit(self):
         """Schluter API always uses celsius."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self):

--- a/custom_components/schluter/sensor.py
+++ b/custom_components/schluter/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT, TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature, UnitOfEnergy, UnitOfPower
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -56,7 +56,7 @@ class SchluterTargetTemperatureSensor(
 ):
     """Representation of a Sensor."""
 
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -94,7 +94,7 @@ class SchluterTargetTemperatureSensor(
 class SchluterTemperatureSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
     """Representation of a Sensor."""
 
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -132,7 +132,7 @@ class SchluterTemperatureSensor(CoordinatorEntity[DataUpdateCoordinator], Sensor
 class SchluterPowerSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
     """Representation of a Sensor."""
 
-    _attr_native_unit_of_measurement = POWER_WATT
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
     _attr_device_class = SensorDeviceClass.POWER
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -172,7 +172,7 @@ class SchluterPowerSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity
 class SchluterEnergySensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
     """Representation of a PowerSensor."""
 
-    _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "AIO Schluter DITRA-HEAT-E WIFI",
-    "homeassistant": "2023.7.0",
+    "homeassistant": "2024.5.3",
     "render_readme": true,
     "zip_release": true,
     "filename": "ha-schluter.zip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,5 +94,5 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.11
-target-version = "py311"
+# Assume Python 3.12
+target-version = "py312"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant==2023.8.1
+homeassistant==2024.5.3
 pip>=23.0
 ruff==0.2.2
 


### PR DESCRIPTION
Hi there, trying to fix warnings prior to release of 2025.1

First off, i'm not familiar with Python and all its ecosystem, i've been programming mainly in java for the last 25 years, so if you want me to change anything, just let me know.

These are the warnings i'm getting when booting a recent 2024 build of HASS:

```
2024-06-23 00:23:08.985 WARNING (ImportExecutor_0) [homeassistant.const] TEMP_CELSIUS was used from schluter, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'schluter' custom integration
2024-06-23 00:23:08.990 WARNING (ImportExecutor_0) [homeassistant.const] ENERGY_KILO_WATT_HOUR was used from schluter, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfEnergy.KILO_WATT_HOUR instead, please report it to the author of the 'schluter' custom integration
2024-06-23 00:23:08.991 WARNING (ImportExecutor_0) [homeassistant.const] POWER_WATT was used from schluter, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPower.WATT instead, please report it to the author of the 'schluter' custom integration
2024-06-23 00:23:08.993 WARNING (ImportExecutor_0) [homeassistant.const] TEMP_CELSIUS was used from schluter, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'schluter' custom integration
2024-06-23 00:23:09.001 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.schluter.climate.SchluterThermostat'>) implements HVACMode(s): heat, auto, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/Ingos11/ha-schluter/issues
```

I've changed the constants as suggested for the first four items.

For the last one, i've found this [blog post](https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/) explaining what needed to be done. Looking at the code for the [turn_on](https://github.com/home-assistant/core/blob/2024.5.3/homeassistant/components/climate/__init__.py#L795) and [turn_off](https://github.com/home-assistant/core/blob/2024.5.3/homeassistant/components/climate/__init__.py#L823) show indeed that it will work.