### PR TITLE
Change to TOTAL_INCREASING for energy sensors

### DIFF
--- a/custom_components/schluter/sensor.py
+++ b/custom_components/schluter/sensor.py
@@ -174,7 +174,7 @@ class SchluterEnergySensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntit
 
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def __init__(
         self,
@@ -223,7 +223,7 @@ class SchluterEnergyPriceSensor(CoordinatorEntity[DataUpdateCoordinator], Sensor
 
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def __init__(
         self,


### PR DESCRIPTION
TOTAL is for devices that net meter, and when the price resets to 0, HA is treating it as return of energy back to the grid of 0 minus whatever the previous value was. TOTAL_INCREASING treats a decrease as a meter reset and just starts counting upward, which means it handles Schluter's daily reset to 0 properly