### PR TITLE
Refresh Schluter session ID when expired

### DIFF
--- a/custom_components/schluter/__init__.py
+++ b/custom_components/schluter/__init__.py
@@ -1,4 +1,5 @@
 """The schluter integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -30,18 +31,13 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
-    """Set up this integration using YAML is not supported."""
+async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up schluter from a config entry."""
-
     username: str = entry.data[CONF_USERNAME]
     password: str = entry.data[CONF_PASSWORD]
-
-    _LOGGER.debug("Using username %s to connect to Schluter Api", username)
 
     websession = async_get_clientsession(hass)
     api = SchluterApi(websession)
@@ -49,35 +45,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = SchluterDataUpdateCoordinator(hass, api, username, password)
     await coordinator.async_config_entry_first_refresh()
 
-    schluter_data = SchluterData(api, coordinator)
-
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = schluter_data
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SchluterData(
+        api=api,
+        coordinator=coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        _LOGGER.debug("Unloading configuration entry %s", entry.entry_id)
         hass.data[DOMAIN].pop(entry.entry_id)
-
     return unload_ok
 
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update listener."""
-    _LOGGER.debug("Update Listener for entry %s", entry.entry_id)
     await hass.config_entries.async_reload(entry.entry_id)
 
 
 class SchluterDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Class to manage fetching Schluter temperature data from API."""
-
     def __init__(
         self,
         hass: HomeAssistant,
@@ -85,55 +74,60 @@ class SchluterDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         username: str,
         password: str,
     ) -> None:
-        """Initialize."""
         self._username = username
         self._password = password
         self._api = api
-        self._sessionid = None
-        self._counter = 0
+        self._sessionid: str | None = None
 
-        update_interval = timedelta(minutes=1)
-        _LOGGER.debug("Data will be update every %s", update_interval)
-
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=1),
+        )
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Update data via schluter library."""
         try:
             async with async_timeout.timeout(10):
                 if self._sessionid is None:
-                    _LOGGER.info("No Schluter Sessionid found, authenticating")
                     self._sessionid = await self._api.async_get_sessionid(
-                        self._username, self._password
+                        self._username,
+                        self._password,
                     )
-                # add 1 day to the session timestamp to be able to check against
-                # the current time. if the time is expired renew the sessionid.
-                # This workaround mediates the missing long lived tokens on
-                # this Schluter API side.
-                expiration_timestamp = self._api.sessionid_timestamp + timedelta(
-                    days=+1
-                )
-                _LOGGER.debug(
-                    "Sessionid expiration timestamp is: %s",
-                    expiration_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+
+                expiration_timestamp = (
+                    self._api.sessionid_timestamp + timedelta(days=1)
                 )
                 if expiration_timestamp <= datetime.now():
-                    _LOGGER.info("Schluter Sessionid is expired, authenticating again")
                     self._sessionid = await self._api.async_get_sessionid(
-                        self._username, self._password
+                        self._username,
+                        self._password,
                     )
+
                 return await self._api.async_get_current_thermostats(self._sessionid)
-        except InvalidSessionIdError as err:
-            raise ConfigEntryAuthFailed from err
+
+        except InvalidSessionIdError:
+            try:
+                self._sessionid = await self._api.async_get_sessionid(
+                    self._username,
+                    self._password,
+                )
+                return await self._api.async_get_current_thermostats(self._sessionid)
+
+            except InvalidUserPasswordError as err:
+                raise ConfigEntryAuthFailed from err
+
+            except (ApiError, ClientConnectorError) as err:
+                raise UpdateFailed(err) from err
+
         except InvalidUserPasswordError as err:
             raise ConfigEntryAuthFailed from err
+
         except (ApiError, ClientConnectorError) as err:
             raise UpdateFailed(err) from err
 
 
 @dataclass
 class SchluterData:
-    """Data for the schluter integration."""
-
     api: SchluterApi
     coordinator: SchluterDataUpdateCoordinator


### PR DESCRIPTION
Fix as outlined in: https://github.com/IngoS11/ha-schluter/issues/9#issuecomment-3648165035

This updates `SchluterDataUpdateCoordinator` to:

- Keeps the proactive one-day expiration logic based on `sessionid_timestamp`
- On `InvalidSessionIdError`, attempts a single forced re-auth using the stored username and password and retries the data fetch
- Only raises `ConfigEntryAuthFailed` if:
  - The re-auth path raises `InvalidUserPasswordError`, or
  - Initial login or timestamp-based renewal raises `InvalidUserPasswordError`
- Treats `ApiError` and `ClientConnectorError` as transient `UpdateFailed` errors

With this change, the integration transparently reauthenticates when the backend rejects the current `sessionid`, and the config entry no longer enters the Reconfigure state in my environment.

