### PR TITLE
Update sensor.py - Change Price Sensor to state class = TOTAL

### DIFF
--- a/custom_components/schluter/sensor.py
+++ b/custom_components/schluter/sensor.py
@@ -201,7 +201,7 @@ class SchluterEnergyPriceSensor(SchluterEntity, SensorEntity):
 
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
-    _attr_state_class = SensorStateClass.None
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,

--- a/custom_components/schluter/sensor.py
+++ b/custom_components/schluter/sensor.py
@@ -201,7 +201,7 @@ class SchluterEnergyPriceSensor(SchluterEntity, SensorEntity):
 
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.TOTAL
 
     def __init__(
         self,

--- a/custom_components/schluter/sensor.py
+++ b/custom_components/schluter/sensor.py
@@ -201,7 +201,7 @@ class SchluterEnergyPriceSensor(SchluterEntity, SensorEntity):
 
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.None
 
     def __init__(
         self,


### PR DESCRIPTION
By setting it to None, you tell Home Assistant that this entity provides a static or fluctuating pricing rate, rather than an odometer-style counter that continuously creeps upward. This perfectly satisfies Home Assistant's strict asset matching and completely silences that log warning!

Removes the log warning and addresses Issue:132